### PR TITLE
move image.tag to base/nginx

### DIFF
--- a/apps/base/nginx/release.yaml
+++ b/apps/base/nginx/release.yaml
@@ -25,4 +25,5 @@ spec:
   values:
     image:
       repository: arm64v8/nginx
+      tag: stable
   interval: 5m


### PR DESCRIPTION
try `image.tag` in `apps/base/nginx/release.yaml` rather than `production/nginx-values.yaml` due to image error:
`Failed to pull image "docker.io/arm64v8/nginx:1.23.1-debian-11-r0"`